### PR TITLE
ENH: improve error handling

### DIFF
--- a/pythia-gallery.mjs
+++ b/pythia-gallery.mjs
@@ -1,8 +1,7 @@
-import { spawn } from 'node:child_process';
-
+import { spawn } from "node:child_process";
 
 /**
- * Call out to an external process that conforms to a JSON-based 
+ * Call out to an external process that conforms to a JSON-based
  * stdin-stdout transform specification.
  *
  * @param opts transform options, containing the binary path and arguments
@@ -50,23 +49,23 @@ function externalTransform(opts) {
 }
 
 const cookbooksTransform = () =>
-  externalTransform({ executable: 'python3', args: ['pythia-gallery.py'] });
+  externalTransform({ executable: "python3", args: ["pythia-gallery.py"] });
 
 const pythiaGalleryDirective = {
-  name: 'pythia-cookbooks',
-  doc: 'An example directive for embedding a Pythia cookbook gallery.',
+  name: "pythia-cookbooks",
+  doc: "An example directive for embedding a Pythia cookbook gallery.",
   run() {
-    const img = { type: 'pythia-cookbooks', children: [] };
+    const img = { type: "pythia-cookbooks", children: [] };
     return [img];
   },
 };
 const pythiaGalleryTransform = {
   plugin: cookbooksTransform,
-  stage: 'document',
+  stage: "document",
 };
 
 const plugin = {
-  name: 'Pythia Gallery',
+  name: "Pythia Gallery",
   directives: [pythiaGalleryDirective],
   transforms: [pythiaGalleryTransform],
 };

--- a/pythia-gallery.mjs
+++ b/pythia-gallery.mjs
@@ -17,17 +17,31 @@ function externalTransform(opts) {
     subprocess.stdin.end();
 
     // Read out the response in chunks
-    const buffers = [];
-    subprocess.stdout.on('data', (chunk) => {
-      buffers.push(chunk);
+    const stdoutBuffers = [];
+    subprocess.stdout.on("data", (chunk) => {
+      stdoutBuffers.push(chunk);
+    });
+    const stderrBuffers = [];
+    subprocess.stderr.on("data", (chunk) => {
+      stderrBuffers.push(chunk);
     });
 
     // Await exit
-    await new Promise((resolve) => {
-      subprocess.on('close', resolve);
+    const exitCode = await new Promise((resolve) => {
+      subprocess.on("close", (code) => resolve(code));
     });
+    if (exitCode) {
+      const stderr = Buffer.concat(stderrBuffers).toString();
+      throw new Error(
+        `Non-zero error code while running pythia-gallery'\n\n${stderr}`,
+      );
+    } else if (stderrBuffers.length) {
+      const stderr = Buffer.concat(stderrBuffers).toString();
+      // Log the error
+      console.debug(`\n\n${stderr}\n\n`);
+    }
     // Concatenate the responses
-    const stdout = Buffer.concat(buffers).toString();
+    const stdout = Buffer.concat(stdoutBuffers).toString();
 
     // Modify the tree in-place
     const result = JSON.parse(stdout);


### PR DESCRIPTION
This PR:
- Now reads `myst.yml` for project metadata instead of `_config.yml`
- Reports more information about the build for debugging.

In the near future, https://github.com/jupyter-book/mystmd/pull/1329 will make this much cleaner.